### PR TITLE
feat(authui-container): Add support for Japanese characters in UI config

### DIFF
--- a/authui-container/common/config-builder.ts
+++ b/authui-container/common/config-builder.ts
@@ -49,7 +49,7 @@ const VALIDATION_TREE: validators.ValidationTree = {
       },
       selectTenantUiTitle: {
         validator: (value: any, key: string) => {
-          if (!validators.isSafeString(value)) {
+          if (!validators.isSafeWideString(value)) {
             throw new Error(`"${key}" should be a valid string.`);
           }
         },
@@ -95,7 +95,7 @@ const VALIDATION_TREE: validators.ValidationTree = {
               },
               displayName: {
                 validator: (value: any, key: string) => {
-                  if (!validators.isSafeString(value)) {
+                  if (!validators.isSafeWideString(value)) {
                     throw new Error(`"${key}" should be a valid string.`);
                   }
                 },
@@ -191,7 +191,7 @@ const VALIDATION_TREE: validators.ValidationTree = {
                   },
                   providerName: {
                     validator: (value: any, key: string) => {
-                      if (!validators.isSafeString(value)) {
+                      if (!validators.isSafeWideString(value)) {
                         throw new Error(`"${key}" should be a valid string.`);
                       }
                     },
@@ -356,7 +356,7 @@ const VALIDATION_TREE: validators.ValidationTree = {
 /** Utility for building the default UI config object. */
 export class DefaultUiConfigBuilder {
   private static uiConfigValidator: validators.JsonObjectValidator =
-      new validators.JsonObjectValidator(VALIDATION_TREE, REQUIRED_FIELDS);
+    new validators.JsonObjectValidator(VALIDATION_TREE, REQUIRED_FIELDS);
 
   /**
    * Validates the provided UiConfig object.
@@ -373,9 +373,9 @@ export class DefaultUiConfigBuilder {
    * @param tenantUiConfigMap The map of tenant IDs to TenantUiConfig object.
    */
   constructor(
-      private readonly projectId: string,
-      private readonly hostName: string,
-      private readonly gcipConfig: GcipConfig,
+    private readonly projectId: string,
+    private readonly hostName: string,
+    private readonly gcipConfig: GcipConfig,
       private readonly tenantUiConfigMap: {[key: string]: TenantUiConfig}) {}
 
   /**
@@ -400,12 +400,12 @@ export class DefaultUiConfigBuilder {
       if (tenantId.charAt(0) === '_') {
         key = '_';
         displayName = (optionsMap[key] && optionsMap[key].displayName) ||
-            'My Company';
+          'My Company';
         fullLabel = optionsMap[key] && optionsMap[key].fullLabel;
       } else {
         key = tenantId;
         displayName = (optionsMap[key] && optionsMap[key].displayName) ||
-            `Company ${String.fromCharCode(charCode)}`;
+          `Company ${String.fromCharCode(charCode)}`;
         fullLabel = optionsMap[key] && optionsMap[key].fullLabel;
         charCode++;
       }

--- a/authui-container/common/validator.ts
+++ b/authui-container/common/validator.ts
@@ -147,8 +147,8 @@ export function isURL(urlStr: any): boolean {
     const pathnameRe = /^(\/+[\w\-\.\~\!\$\'\(\)\*\+\,\;\=\:\@\%]+)*\/*$/;
     // Validate pathname.
     if (pathname &&
-        !/^\/+$/.test(pathname) &&
-        !pathnameRe.test(pathname)) {
+      !/^\/+$/.test(pathname) &&
+      !pathnameRe.test(pathname)) {
       return false;
     }
     // Allow any query string and hash as long as no invalid character is used.
@@ -180,7 +180,7 @@ export function isLocalhostOrHttpsURL(urlStr: any): boolean {
   if (isURL(urlStr)) {
     const uri = new URL(urlStr);
     return (uri.protocol === 'http:' && uri.hostname === 'localhost') ||
-        uri.protocol === 'https:';
+      uri.protocol === 'https:';
   }
   return false;
 }
@@ -253,6 +253,21 @@ export function isSafeString(value: any): boolean {
   }
   // This check only allows limited set of characters and spaces.
   const re = /^[a-zA-Z0-9\-\_\.\s\,\+\?\!\&\;]+$/;
+  return isNonEmptyString(value) && re.test(value);
+}
+
+/**
+ * Validates that the input is a safe string including Japanese characters. This minimizes the risk of XSS.
+ *
+ * @param value The string to validate.
+ * @return Whether the string is safe or not.
+ */
+export function isSafeWideString(value: any): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  // This check allows alphanumeric characters, spaces, basic punctuation, and Japanese characters (hiragana, katakana, kanji, punctuation).
+  const re = /^[a-zA-Z0-9\-\_\.\s\,\+\?\!\&\;\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF\u3400-\u4DBF\u3000-\u303F\uFF00-\uFFEF]+$/;
   return isNonEmptyString(value) && re.test(value);
 }
 

--- a/authui-container/test/unit/common/config-builder.spec.ts
+++ b/authui-container/test/unit/common/config-builder.spec.ts
@@ -913,6 +913,96 @@ describe('DefaultUiConfigBuilder', () => {
     });
   });
 
+  describe('Japanese character support with isSafeWideString', () => {
+    it('should accept Japanese characters in selectTenantUiTitle', () => {
+      expect(() => {
+        const configWithJapanese: any = deepCopy(expectedUiConfig);
+        configWithJapanese[API_KEY].selectTenantUiTitle = 'テナント選択';
+        DefaultUiConfigBuilder.validateConfig(configWithJapanese);
+      }).not.to.throw();
+    });
+
+    it('should accept mixed Japanese and English in selectTenantUiTitle', () => {
+      expect(() => {
+        const configWithJapanese: any = deepCopy(expectedUiConfig);
+        configWithJapanese[API_KEY].selectTenantUiTitle = 'Portal ポータル';
+        DefaultUiConfigBuilder.validateConfig(configWithJapanese);
+      }).not.to.throw();
+    });
+
+    it('should accept Japanese punctuation in selectTenantUiTitle', () => {
+      expect(() => {
+        const configWithJapanese: any = deepCopy(expectedUiConfig);
+        configWithJapanese[API_KEY].selectTenantUiTitle = 'こんにちは、世界！';
+        DefaultUiConfigBuilder.validateConfig(configWithJapanese);
+      }).not.to.throw();
+    });
+
+    it('should accept Japanese characters in tenant displayName', () => {
+      expect(() => {
+        const configWithJapanese: any = deepCopy(expectedUiConfig);
+        configWithJapanese[API_KEY].tenants._.displayName = '会社名';
+        DefaultUiConfigBuilder.validateConfig(configWithJapanese);
+      }).not.to.throw();
+    });
+
+    it('should accept hiragana, katakana, and kanji in tenant displayName', () => {
+      expect(() => {
+        const configWithJapanese: any = deepCopy(expectedUiConfig);
+        configWithJapanese[API_KEY].tenants._.displayName = 'ひらがな カタカナ 漢字';
+        DefaultUiConfigBuilder.validateConfig(configWithJapanese);
+      }).not.to.throw();
+    });
+
+    it('should accept Japanese characters in provider providerName', () => {
+      expect(() => {
+        const configWithJapanese: any = deepCopy(expectedUiConfig);
+        configWithJapanese[API_KEY].tenants._.signInOptions[2].providerName = 'SAML プロバイダー';
+        DefaultUiConfigBuilder.validateConfig(configWithJapanese);
+      }).not.to.throw();
+    });
+
+    it('should accept full-width characters in providerName', () => {
+      expect(() => {
+        const configWithJapanese: any = deepCopy(expectedUiConfig);
+        configWithJapanese[API_KEY].tenants._.signInOptions[2].providerName = 'ＳＡＭＬプロバイダー１２３';
+        DefaultUiConfigBuilder.validateConfig(configWithJapanese);
+      }).not.to.throw();
+    });
+
+    it('should accept Japanese text with brackets and punctuation in displayName', () => {
+      expect(() => {
+        const configWithJapanese: any = deepCopy(expectedUiConfig);
+        configWithJapanese[API_KEY].tenants._.displayName = '株式会社（テスト）';
+        DefaultUiConfigBuilder.validateConfig(configWithJapanese);
+      }).not.to.throw();
+    });
+
+    it('should reject HTML-like content mixed with Japanese in selectTenantUiTitle', () => {
+      expect(() => {
+        const configWithJapanese: any = deepCopy(expectedUiConfig);
+        configWithJapanese[API_KEY].selectTenantUiTitle = 'こんにちは<script>alert("test")</script>';
+        DefaultUiConfigBuilder.validateConfig(configWithJapanese);
+      }).to.throw('"API_KEY.selectTenantUiTitle" should be a valid string.');
+    });
+
+    it('should reject unsafe characters mixed with Japanese in displayName', () => {
+      expect(() => {
+        const configWithJapanese: any = deepCopy(expectedUiConfig);
+        configWithJapanese[API_KEY].tenants._.displayName = '会社名<div>';
+        DefaultUiConfigBuilder.validateConfig(configWithJapanese);
+      }).to.throw('"API_KEY.tenants._.displayName" should be a valid string.');
+    });
+
+    it('should reject unsafe characters in providerName with Japanese', () => {
+      expect(() => {
+        const configWithJapanese: any = deepCopy(expectedUiConfig);
+        configWithJapanese[API_KEY].tenants._.signInOptions[2].providerName = 'プロバイダー"test"';
+        DefaultUiConfigBuilder.validateConfig(configWithJapanese);
+      }).to.throw('"API_KEY.tenants._.signInOptions[].providerName" should be a valid string.');
+    });
+  });
+
   describe('build()', () => {
     it('should return expected populated UiConfig', () => {
       const configBuilder = new DefaultUiConfigBuilder(PROJECT_ID, '', gcipConfig, tenantUiConfigMap);


### PR DESCRIPTION
This change introduces a new validation function, `isSafeWideString`, to allow the use of Japanese characters (Hiragana, Katakana, Kanji, and punctuation) in certain UI configuration fields.

The following fields now support Japanese characters:
- `selectTenantUiTitle`
- `tenants.*.displayName`
- `tenants.*.signInOptions.*.providerName`

The `isSafeString` validator was replaced with the new `isSafeWideString` for these fields to provide wider language support while still preventing unsafe inputs that could lead to XSS vulnerabilities.

Unit tests have been added for the new validator and to verify that the configuration builder correctly accepts Japanese strings in the appropriate fields.